### PR TITLE
Sync contributor list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,68 +6,68 @@ Please refer to the [contributors data](https://github.com/newton-physics/newton
 
 Not listing Project Members that also serve as Maintainers or TSC Members.
 
-* Nicolas Capens
-* Christopher Crouzet
-* Andrew Kaufman
-* apradhana
-* Kelly Guo
-* Michael Sauter
-* Adam Moravanszky
-* Ossama Ahmed
-* etaoxing
-* Ruben Grandia
-* Anka Chen
-* Ales Borovicka
-* Gordon Yeoman
-* Yutaka Yoshisaka
-* Zach Corse
-* dylanturpin
-* moennen
-* Guirec-Maloisel
-* Antoine RICHARD
-* Lukasz Wawrzyniak
-* Viktor Reutskyy
-* Wenchao Huang
-* Mustafa H
-* Agon Serifi
-* gdaviet
-* Akhil-Docca
-* Lennart Röstel
-* Philipp Reist
-* nvtw
-* JC-nvidia
-* Daniela Hase
-* tconceicaoNV
-* nv-rthaker
-* Kenny Vilella
-* Milad-Rakhsha-NV
-* neelkm
-* Julia von Muralt
-* nv-rgresia
-* camevor
-* Christian Schumacher
-* David
-* mzamoramora-nvidia
-* Dex Smither
-* Jeff Hough NV
-* frankchenlw
-* jenv-nv
+* Nicolas Capens (@c0d1f1ed)
+* Christopher Crouzet (@christophercrouzet)
+* Andrew Kaufman (@andrewkaufman)
+* @apradhana
+* Kelly Guo (@kellyguo11)
+* Michael Sauter (@msauter-nvidia)
+* Adam Moravanszky (@amoravanszky)
+* Ossama Ahmed (@ossamaAhmed)
+* etaoxing (@etaoxing)
+* Ruben Grandia (@rubengrandia)
+* Anka Chen (@AnkaChan)
+* Ales Borovicka (@AlesBorovicka)
+* Gordon Yeoman (@gyeomannvidia)
+* Yutaka Yoshisaka (@ft-lab)
+* Zach Corse (@daedalus5)
+* @dylanturpin
+* @moennen
+* @Guirec-Maloisel
+* Antoine RICHARD (@AntoineRichard)
+* Lukasz Wawrzyniak (@nvlukasz)
+* Viktor Reutskyy (@vreutskyy)
+* Wenchao Huang (@WenchaoHuang)
+* Mustafa H (@StafaH)
+* Agon Serifi (@aserifi)
+* @gdaviet
+* @Akhil-Docca
+* Lennart Röstel (@lenroe)
+* Philipp Reist (@preist-nvidia)
+* @nvtw
+* JC (@jumyungc)
+* Daniela Hase (@daniela-hase)
+* @tconceicaoNV
+* nv-rthaker (@rthaker01)
+* Kenny Vilella (@Kenny-Vilella)
+* @Milad-Rakhsha-NV
+* @neelkm
+* Julia von Muralt (@jvonmuralt)
+* @nv-rgresia
+* @camevor
+* Christian Schumacher (@chschuma-disney)
+* David Cao-Mueller (@david-cao-mueller)
+* @mzamoramora-nvidia
+* Dex Smither (@dsmither-lgtm)
+* Jeff Hough NV (@jeff-hough)
+* @frankchenlw
+* @jenv-nv
 
 # Maintainers
 
-* Miles Macklin
-* Saran Tunyasuvunakool
-* Vassilios Tsounis
-* Eric Heiden
-* Jan Carius
-* Eric Shi
-* Alain Denzler
+* Miles Macklin (@mmacklin)
+* Saran Tunyasuvunakool (@saran-t)
+* Vassilios Tsounis (@vastsoun)
+* Eric Heiden (@eric-heiden)
+* Jan Carius (@jcarius-nv)
+* Eric Shi (@shi-eric)
+* Alain Denzler (@adenzler-nvidia)
 
 # TSC Members
 
-* Erik Frey
-* Miles Macklin
-* Vassilios Tsounis - co-chair
-* Yuval Tassa
-* moritzbaecher
-* Mohammad Mohajerani - co-chair
+* Erik Frey (@erikfrey)
+* Miles Macklin (@mmacklin)
+* Vassilios Tsounis (@vastsoun) - co-chair
+* Yuval Tassa (@yuvaltassa)
+* @moritzbaecher
+* Mohammad Mohajerani (@momo-van) - co-chair

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,61 +4,70 @@ Please refer to the [contributors data](https://github.com/newton-physics/newton
 
 # Project Members
 
-Not listing Project Members that also serve as Maintainers.
+Not listing Project Members that also serve as Maintainers or TSC Members.
 
+* Nicolas Capens
 * Christopher Crouzet
 * Andrew Kaufman
-* Andre Pradhana
+* apradhana
 * Kelly Guo
-* Michael Sauter  
+* Michael Sauter
 * Adam Moravanszky
-* Ossama Ahmed  
+* Ossama Ahmed
+* etaoxing
+* Ruben Grandia
 * Anka Chen
 * Ales Borovicka
 * Gordon Yeoman
+* Yutaka Yoshisaka
 * Zach Corse
-* Dylan Turpin
-* Antoine Richard
+* dylanturpin
+* moennen
+* Guirec-Maloisel
+* Antoine RICHARD
 * Lukasz Wawrzyniak
 * Viktor Reutskyy
 * Wenchao Huang
-* Gilles Daviet
-* Akhil Docca
-* Tobias Widmer
-* JC Chang
-* Teresa Conceicao
-* Ruchik Thaker
-* Milad Rakhsha
-* Neelakantan Mani
-* Julia von Muralt
-* Ryan Gresia
-* Chris Amevor  
-* Miguel Zamora
-* Lennart Roestel
-* Guirec Maloisel 
-* Christian Schumacher
-* Ruben Grandia
+* Mustafa H
 * Agon Serifi
-* David Cao-Müller
-* Lou Rohan
-* Yutaka Yoshisaka
+* gdaviet
+* Akhil-Docca
+* Lennart Röstel
+* Philipp Reist
+* nvtw
+* JC-nvidia
+* Daniela Hase
+* tconceicaoNV
+* nv-rthaker
+* Kenny Vilella
+* Milad-Rakhsha-NV
+* neelkm
+* Julia von Muralt
+* nv-rgresia
+* camevor
+* Christian Schumacher
+* David
+* mzamoramora-nvidia
+* Dex Smither
+* Jeff Hough NV
+* frankchenlw
+* jenv-nv
 
 # Maintainers
 
-* Saran Tunyasuvunakool
-* Eric Shi
-* Eric Heiden
-* Philipp Reist
-* Vassilios Tsounis
 * Miles Macklin
+* Saran Tunyasuvunakool
+* Vassilios Tsounis
+* Eric Heiden
+* Jan Carius
+* Eric Shi
 * Alain Denzler
-* Kenny Vilella
 
 # TSC Members
 
-* Moritz Baecher
+* Erik Frey
+* Miles Macklin
 * Vassilios Tsounis - co-chair
 * Yuval Tassa
-* Erik Frey
+* moritzbaecher
 * Mohammad Mohajerani - co-chair
-* Miles Macklin

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,57 +2,6 @@
 
 Please refer to the [contributors data](https://github.com/newton-physics/newton/graphs/contributors) in the repository insights.
 
-# Project Members
-
-Not listing Project Members that also serve as Maintainers or TSC Members.
-
-* Nicolas Capens (@c0d1f1ed)
-* Christopher Crouzet (@christophercrouzet)
-* Andrew Kaufman (@andrewkaufman)
-* @apradhana
-* Kelly Guo (@kellyguo11)
-* Michael Sauter (@msauter-nvidia)
-* Adam Moravanszky (@amoravanszky)
-* Ossama Ahmed (@ossamaAhmed)
-* etaoxing (@etaoxing)
-* Ruben Grandia (@rubengrandia)
-* Anka Chen (@AnkaChan)
-* Ales Borovicka (@AlesBorovicka)
-* Gordon Yeoman (@gyeomannvidia)
-* Yutaka Yoshisaka (@ft-lab)
-* Zach Corse (@daedalus5)
-* @dylanturpin
-* @moennen
-* @Guirec-Maloisel
-* Antoine RICHARD (@AntoineRichard)
-* Lukasz Wawrzyniak (@nvlukasz)
-* Viktor Reutskyy (@vreutskyy)
-* Wenchao Huang (@WenchaoHuang)
-* Mustafa H (@StafaH)
-* Agon Serifi (@aserifi)
-* @gdaviet
-* @Akhil-Docca
-* Lennart Röstel (@lenroe)
-* Philipp Reist (@preist-nvidia)
-* @nvtw
-* JC (@jumyungc)
-* Daniela Hase (@daniela-hase)
-* @tconceicaoNV
-* nv-rthaker (@rthaker01)
-* Kenny Vilella (@Kenny-Vilella)
-* @Milad-Rakhsha-NV
-* @neelkm
-* Julia von Muralt (@jvonmuralt)
-* @nv-rgresia
-* @camevor
-* Christian Schumacher (@chschuma-disney)
-* David Cao-Mueller (@david-cao-mueller)
-* @mzamoramora-nvidia
-* Dex Smither (@dsmither-lgtm)
-* Jeff Hough NV (@jeff-hough)
-* @frankchenlw
-* @jenv-nv
-
 # Maintainers
 
 * Miles Macklin (@mmacklin)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The project was initiated by [Disney Research](https://www.disneyresearch.com/),
 
 ## Contributor List
 
-Sync [CONTRIBUTORS.md](CONTRIBUTORS.md) from the `newton-physics` GitHub organization role teams:
+Sync the Maintainers and TSC sections in [CONTRIBUTORS.md](CONTRIBUTORS.md) from the `newton-physics` GitHub organization governance teams:
 
 Prerequisites:
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,22 @@ This repository hosts documents related to Newton project governance and legal, 
 Newton is a [Linux Foundation](https://www.linuxfoundation.org/) project that is community-built and maintained. It is permissively licensed under the Apache-2.0 license.
 
 The project was initiated by [Disney Research](https://www.disneyresearch.com/), [Google DeepMind](https://deepmind.google/), and [NVIDIA](https://www.nvidia.com/).
+
+## Contributor List
+
+Sync [CONTRIBUTORS.md](CONTRIBUTORS.md) from the `newton-physics` GitHub organization role teams:
+
+Prerequisites:
+
+* Python 3.
+* GitHub CLI `gh`.
+* An authenticated `gh` session with access to read the `newton-physics` organization teams. Check with `gh auth status`.
+
+Run the script from this repository root:
+
+```bash
+python3 scripts/sync_contributors.py --write
+python3 scripts/sync_contributors.py --check
+```
+
+The `--write` command updates `CONTRIBUTORS.md` in place. The `--check` command exits non-zero and prints a diff when `CONTRIBUTORS.md` is out of date.

--- a/scripts/sync_contributors.py
+++ b/scripts/sync_contributors.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Sync CONTRIBUTORS.md from GitHub organization teams.
+"""Sync CONTRIBUTORS.md from GitHub governance teams.
 
 The source of truth is the GitHub teams that define Newton project roles.
 """
@@ -15,15 +15,9 @@ from pathlib import Path
 
 
 ORG = "newton-physics"
-PROJECT_MEMBERS_TEAM = "project-members"
 MAINTAINERS_TEAM = "maintainers"
 TSC_TEAM = "newton-tsc"
 CONTRIBUTORS_PATH = Path("CONTRIBUTORS.md")
-
-# Org-level accounts that are not individual project participants.
-EXCLUDED_LOGINS = {
-    "thelinuxfoundation",
-}
 
 TSC_SUFFIXES = {
     "momo-van": " - co-chair",
@@ -105,30 +99,13 @@ def render_entries(users: list[dict], suffixes: dict[str, str] | None = None) ->
 
 
 def render_contributors() -> str:
-    project_team_members = fetch_team_members(PROJECT_MEMBERS_TEAM)
     maintainers = fetch_team_members(MAINTAINERS_TEAM)
     tsc_members = fetch_team_members(TSC_TEAM)
-
-    maintainer_logins = {user["login"] for user in maintainers}
-    tsc_logins = {user["login"] for user in tsc_members}
-    project_members = [
-        user
-        for user in project_team_members
-        if user["login"] not in maintainer_logins
-        and user["login"] not in tsc_logins
-        and user["login"] not in EXCLUDED_LOGINS
-    ]
 
     lines = [
         "# Community Members",
         "",
         "Please refer to the [contributors data](https://github.com/newton-physics/newton/graphs/contributors) in the repository insights.",
-        "",
-        "# Project Members",
-        "",
-        "Not listing Project Members that also serve as Maintainers or TSC Members.",
-        "",
-        *render_entries(project_members),
         "",
         "# Maintainers",
         "",

--- a/scripts/sync_contributors.py
+++ b/scripts/sync_contributors.py
@@ -92,7 +92,11 @@ def fetch_team_members(team: str) -> list[dict]:
 
 
 def display_name(user: dict) -> str:
-    return (user.get("name") or "").strip() or user["login"]
+    login = user["login"]
+    name = (user.get("name") or "").strip()
+    if name:
+        return f"{name} (@{login})"
+    return f"@{login}"
 
 
 def render_entries(users: list[dict], suffixes: dict[str, str] | None = None) -> list[str]:

--- a/scripts/sync_contributors.py
+++ b/scripts/sync_contributors.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Sync CONTRIBUTORS.md from GitHub organization teams.
+
+The source of truth is the GitHub teams that define Newton project roles.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ORG = "newton-physics"
+PROJECT_MEMBERS_TEAM = "project-members"
+MAINTAINERS_TEAM = "maintainers"
+TSC_TEAM = "newton-tsc"
+CONTRIBUTORS_PATH = Path("CONTRIBUTORS.md")
+
+# Org-level accounts that are not individual project participants.
+EXCLUDED_LOGINS = {
+    "thelinuxfoundation",
+}
+
+TSC_SUFFIXES = {
+    "momo-van": " - co-chair",
+    "vastsoun": " - co-chair",
+}
+
+TEAM_MEMBERS_QUERY = """
+query TeamMembers($org: String!, $team: String!, $after: String) {
+  organization(login: $org) {
+    team(slug: $team) {
+      members(first: 100, after: $after, membership: ALL) {
+        nodes {
+          login
+          name
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def run_graphql(query: str, **variables: str | None) -> dict:
+    cmd = ["gh", "api", "graphql", "-f", f"query={query}"]
+    for name, value in variables.items():
+        if value is not None:
+            cmd.extend(["-F", f"{name}={value}"])
+
+    try:
+        completed = subprocess.run(
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        raise SystemExit("error: GitHub CLI `gh` is required") from None
+    except subprocess.CalledProcessError as exc:
+        message = exc.stderr.strip() or exc.stdout.strip()
+        raise SystemExit(f"error: GitHub API request failed: {message}") from exc
+
+    return json.loads(completed.stdout)
+
+
+def fetch_team_members(team: str) -> list[dict]:
+    users: list[dict] = []
+    after: str | None = None
+
+    while True:
+        data = run_graphql(TEAM_MEMBERS_QUERY, org=ORG, team=team, after=after)
+        team_data = data["data"]["organization"]["team"]
+        if team_data is None:
+            raise SystemExit(f"error: team `{team}` not found in `{ORG}`")
+
+        connection = team_data["members"]
+        users.extend(connection["nodes"])
+
+        page_info = connection["pageInfo"]
+        if not page_info["hasNextPage"]:
+            return users
+        after = page_info["endCursor"]
+
+
+def display_name(user: dict) -> str:
+    return (user.get("name") or "").strip() or user["login"]
+
+
+def render_entries(users: list[dict], suffixes: dict[str, str] | None = None) -> list[str]:
+    suffixes = suffixes or {}
+    return [f"* {display_name(user)}{suffixes.get(user['login'], '')}" for user in users]
+
+
+def render_contributors() -> str:
+    project_team_members = fetch_team_members(PROJECT_MEMBERS_TEAM)
+    maintainers = fetch_team_members(MAINTAINERS_TEAM)
+    tsc_members = fetch_team_members(TSC_TEAM)
+
+    maintainer_logins = {user["login"] for user in maintainers}
+    tsc_logins = {user["login"] for user in tsc_members}
+    project_members = [
+        user
+        for user in project_team_members
+        if user["login"] not in maintainer_logins
+        and user["login"] not in tsc_logins
+        and user["login"] not in EXCLUDED_LOGINS
+    ]
+
+    lines = [
+        "# Community Members",
+        "",
+        "Please refer to the [contributors data](https://github.com/newton-physics/newton/graphs/contributors) in the repository insights.",
+        "",
+        "# Project Members",
+        "",
+        "Not listing Project Members that also serve as Maintainers or TSC Members.",
+        "",
+        *render_entries(project_members),
+        "",
+        "# Maintainers",
+        "",
+        *render_entries(maintainers),
+        "",
+        "# TSC Members",
+        "",
+        *render_entries(tsc_members, TSC_SUFFIXES),
+        "",
+    ]
+
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--check", action="store_true", help="exit non-zero if CONTRIBUTORS.md is out of date")
+    mode.add_argument("--write", action="store_true", help="update CONTRIBUTORS.md in place")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    rendered = render_contributors()
+
+    if args.write:
+        CONTRIBUTORS_PATH.write_text(rendered, encoding="utf-8")
+        return 0
+
+    if args.check:
+        current = CONTRIBUTORS_PATH.read_text(encoding="utf-8")
+        if current == rendered:
+            return 0
+
+        diff = difflib.unified_diff(
+            current.splitlines(keepends=True),
+            rendered.splitlines(keepends=True),
+            fromfile=str(CONTRIBUTORS_PATH),
+            tofile=f"{CONTRIBUTORS_PATH} (generated)",
+        )
+        sys.stderr.writelines(diff)
+        return 1
+
+    print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

* Add a `scripts/sync_contributors.py` helper to regenerate `CONTRIBUTORS.md` from the Newton GitHub role teams.
* Regenerate `CONTRIBUTORS.md` from `project-members`, `maintainers`, and `newton-tsc`.
* Document the script prerequisites and usage in `README.md`.
* Ignore Python bytecode cache files.

## Validation

* `python3 scripts/sync_contributors.py --check`
* `python3 -m py_compile scripts/sync_contributors.py`
* `git diff --check`
